### PR TITLE
Compile fix

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -30,7 +30,7 @@
 <compilerflag value="-Ilibogg/include" />
 <compilerflag value="-Ilibvorbis/include" />
 <compilerflag value="-Ilibvorbis/lib" />
-<compilerflag value="-I../libs.src/libvpx" />
+<compilerflag value="-Ilibvpx-generic" />
 <compilerflag value="-I${ANDROID_NDK_ROOT}/sources/cpufeatures" if="android"/>
 
 <file name="common/ExternalInterface.cpp" />
@@ -46,7 +46,7 @@
 <compilerflag value="-Ilibogg/include" />
 <compilerflag value="-Ilibvorbis/include" />
 <compilerflag value="-Ilibvorbis/lib" />
-<compilerflag value="-I../libs.src/libvpx" />
+<compilerflag value="-Ilibvpx-generic" />
 <compilerflag value="-I${ANDROID_NDK_ROOT}/sources/cpufeatures" if="android"/>
 
 <file name="libwebm/vttreader.cc" />

--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -14,6 +14,7 @@
 #include <hx/CFFI.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <cstdlib>
 #include <assert.h>
 #include <math.h>
@@ -631,7 +632,7 @@ extern "C" {
 					}
 				}
 			
-				printf("Vorbis: version:%d, channels:%d, rate:%d\n", mVorbisInfo.version, mVorbisInfo.channels, mVorbisInfo.rate);
+				printf("Vorbis: version:%d, channels:%d, rate:%ld\n", mVorbisInfo.version, mVorbisInfo.channels, mVorbisInfo.rate);
 				
 				status = vorbis_synthesis_init(&mVorbisDsp, &mVorbisInfo); 
 				if (status < 0) {
@@ -838,8 +839,8 @@ extern "C" {
 
 						printf("\t\tAudio Channels\t\t: %lld\n", pAudioTrack->GetChannels());
 						printf("\t\tAudio BitDepth\t\t: %lld\n", pAudioTrack->GetBitDepth());
-						printf("\t\tAddio Sample Rate\t: %.3f\n", pAudioTrack->GetSamplingRate());
-						printf("\t\tAddio Private Data\t: %p, %d\n", privateDataPointer, privateDataSize);
+						printf("\t\tAudio Sample Rate\t: %.3f\n", pAudioTrack->GetSamplingRate());
+						printf("\t\tAudio Private Data\t: %p, %ld\n", privateDataPointer, privateDataSize);
 						
 						this->vorbisDecoder->parseHeader(privateDataPointer, privateDataSize);
 					}


### PR DESCRIPTION
I could not compile for OS X, this resolves the include path for vpx in ExternalInterface, fixes the missing "va_start" reference, as well as warnings on some of the printf statements 
